### PR TITLE
Use throttle instead of debounce for button

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ var Cap = require('cap').Cap,
         this.dashButtons = {};
 
         this.register = function (button) {
-            button.callback = _.debounce(button.callback, 10000);
+            button.callback = _.throttle(button.callback, 10000);
             self.dashButtons[button.mac.toUpperCase()] = button;
             return self;
         };


### PR DESCRIPTION
Throttle sends the dash button event immediately, instead of waiting for 10 seconds. It still only allows 1 event every 10 seconds though.